### PR TITLE
Fix the order of versions to get the correct latest version

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -4,4 +4,4 @@ set -eu -o pipefail
 
 release_url="https://api.github.com/repos/shirok/Gauche/releases"
 
-curl -fsS $release_url | jq -rM '.[] | .tag_name' | sed -e 's/release//; s/_\([0-9]\)/.\1/g; s/_\(.*\)/-\1/' | tr '\012' ' '
+curl -fsS $release_url | jq -rM '.[] | .tag_name' | sed -e 's/release//; s/_\([0-9]\)/.\1/g; s/_\(.*\)/-\1/' | tac | tr '\012' ' '


### PR DESCRIPTION
`asdf` treats the last one in the output of `bin/list-all` as the most recent version.

ref: https://asdf-vm.com/plugins/create.html#bin-list-all

This is current behavior.

```
❯ asdf list-all gauche
0.9.11-p1
0.9.11
0.9.10
0.9.9
0.9.8
0.9.7
0.9.6

❯ asdf latest gauche
0.9.6
```

The latest version should be `0.9.11-p1` at this case.
This PR fix the above behavior.